### PR TITLE
Restore Topic Summary & Timeline Journal features

### DIFF
--- a/assets/javascripts/discourse/components/journal-topic-map-summary.gjs
+++ b/assets/javascripts/discourse/components/journal-topic-map-summary.gjs
@@ -1,0 +1,164 @@
+import Component from "@glimmer/component";
+import { htmlSafe } from "@ember/template";
+import DButton from "discourse/components/d-button";
+import RelativeDate from "discourse/components/relative-date";
+import TopicParticipants from "discourse/components/topic-map/topic-participants";
+import number from "discourse/helpers/number";
+import slice from "discourse/helpers/slice";
+import i18n from "discourse-common/helpers/i18n";
+import { avatarImg } from "discourse-common/lib/avatar-utils";
+import gt from "truth-helpers/helpers/gt";
+
+export default class JournalTopicMapSummary extends Component {
+  get toggleMapButton() {
+    return {
+      title: this.args.collapsed
+        ? "topic.expand_details"
+        : "topic.collapse_details",
+      icon: this.args.collapsed ? "chevron-down" : "chevron-up",
+      ariaExpanded: this.args.collapsed ? "false" : "true",
+      ariaControls: "topic-map-expanded",
+      action: this.args.toggleMap,
+    };
+  }
+
+  get shouldShowParticipants() {
+    return (
+      this.args.collapsed &&
+      this.args.postAttrs.topicPostsCount > 2 &&
+      this.args.postAttrs.participants &&
+      this.args.postAttrs.participants.length > 0
+    );
+  }
+
+  get createdByAvatar() {
+    return htmlSafe(
+      avatarImg({
+        avatarTemplate: this.args.postAttrs.createdByAvatarTemplate,
+        size: "tiny",
+        title:
+          this.args.postAttrs.createdByName ||
+          this.args.postAttrs.createdByUsername,
+      })
+    );
+  }
+
+  get journalAuthorAvatar() {
+    return htmlSafe(
+      avatarImg({
+        avatarTemplate: this.args.postAttrs.topic.journal_author.avatar_template,
+        size: "tiny",
+        title:
+          this.args.postAttrs.topic.journal_author.name ||
+          this.args.postAttrs.topic.journal_author.username,
+      })
+    );
+  }
+
+  get lastEntryUrl() {
+    return this.args.postAttrs.topicUrl + "/" + this.args.postAttrs.topic.last_entry_post_number;
+  }
+
+  <template>
+    <nav class="buttons">
+      <DButton
+        @icon={{this.toggleMapButton.icon}}
+        @title={{this.toggleMapButton.title}}
+        @ariaExpanded={{this.toggleMapButton.ariaExpanded}}
+        @ariaControls={{this.toggleMapButton.ariaControls}}
+        @action={{this.toggleMapButton.action}}
+        class="btn"
+      />
+    </nav>
+    <ul>
+      <li class="created-at">
+        <h4 role="presentation">{{i18n "created_lowercase"}}</h4>
+        <div class="topic-map-post created-at">
+          <a
+            class="trigger-user-card"
+            data-user-card={{@postAttrs.createdByUsername}}
+            title={{@postAttrs.createdByUsername}}
+            aria-hidden="true"
+          />
+          {{this.createdByAvatar}}
+          <RelativeDate @date={{@postAttrs.topicCreatedAt}} />
+        </div>
+      </li>
+      <li class="last-entry">
+        <a href={{this.lastEntryUrl}}>
+          <h4 role="presentation">{{i18n "last_entry_lowercase"}}</h4>
+          <div class="topic-map-post last-entry">
+            <a
+              class="trigger-user-card"
+              data-user-card={{@postAttrs.topic.journal_author.username}}
+              title={{@postAttrs.topic.journal_author.username}}
+              aria-hidden="true"
+            />
+            {{this.journalAuthorAvatar}}
+            <RelativeDate @date={{@postAttrs.lastPostAt}} />
+          </div>
+        </a>
+      </li>
+      <li class="replies">
+        {{number @postAttrs.topic.entry_count noTitle="true"}}
+        <h4 role="presentation">{{i18n
+            "entry_lowercase"
+            count=@postAttrs.topic.entry_count
+          }}</h4>
+      </li>
+      <li class="replies">
+        {{number @postAttrs.topic.comment_count noTitle="true"}}
+        <h4 role="presentation">{{i18n
+            "comment_lowercase"
+            count=@postAttrs.topic.comment_count
+          }}</h4>
+      </li>
+      <li class="secondary views">
+        {{number
+          @postAttrs.topicViews
+          noTitle="true"
+          class=@postAttrs.topicViewsHeat
+        }}
+        <h4 role="presentation">{{i18n
+            "views_lowercase"
+            count=@postAttrs.topicViews
+          }}</h4>
+      </li>
+      {{#if (gt @postAttrs.participantCount 0)}}
+        <li class="secondary users">
+          {{number @postAttrs.participantCount noTitle="true"}}
+          <h4 role="presentation">{{i18n
+              "users_lowercase"
+              count=@postAttrs.participantCount
+            }}</h4>
+        </li>
+      {{/if}}
+      {{#if (gt @postAttrs.topicLikeCount 0)}}
+        <li class="secondary likes">
+          {{number @postAttrs.topicLikeCount noTitle="true"}}
+          <h4 role="presentation">{{i18n
+              "likes_lowercase"
+              count=@postAttrs.topicLikeCount
+            }}</h4>
+        </li>
+      {{/if}}
+      {{#if (gt @postAttrs.topicLinkCount 0)}}
+        <li class="secondary links">
+          {{number @postAttrs.topicLinkCount noTitle="true"}}
+          <h4 role="presentation">{{i18n
+              "links_lowercase"
+              count=@postAttrs.topicLinkCount
+            }}</h4>
+        </li>
+      {{/if}}
+      {{#if this.shouldShowParticipants}}
+        <li class="avatars">
+          <TopicParticipants
+            @participants={{slice 0 3 @postAttrs.participants}}
+            @userFilters={{@postAttrs.userFilters}}
+          />
+        </li>
+      {{/if}}
+    </ul>
+  </template>
+}

--- a/assets/javascripts/discourse/initializers/journal-topic.js
+++ b/assets/javascripts/discourse/initializers/journal-topic.js
@@ -1,10 +1,9 @@
 import discourseComputed, { on, observes } from "discourse-common/utils/decorators";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
-import { avatarFor } from "discourse/widgets/post";
-import { dateNode, numberNode } from "discourse/helpers/node";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import RenderGlimmer from "discourse/widgets/render-glimmer";
 import { scheduleOnce } from "@ember/runloop";
-import { h } from "virtual-dom";
+import { hbs } from "ember-cli-htmlbars";
 import { deepMerge } from "discourse-common/lib/object";
 
 const PLUGIN_ID = "discourse-journal";
@@ -127,138 +126,32 @@ export default {
         }
       });
 
-      function renderParticipants(userFilters, participants) {
-        if (!participants) {
-          return;
-        }
+      api.reopenWidget("topic-map", {
+        buildTopicMapSummary(attrs, state) {
+            if (!attrs.journal)
+              return this._super(attrs, state);
 
-        userFilters = userFilters || [];
-        return participants.map(p => {
-          return this.attach("topic-participant", p, {
-            state: { toggled: userFilters.includes(p.username) }
-          });
-        });
-      }
+            const { collapsed } = state;
+            const wrapperClass = collapsed
+              ? "section.map.map-collapsed"
+              : "section.map";
 
-      //TODO This breaks in 3.2.x due to missing topic-participant widget.
-      //   api.reopenWidget("topic-map-summary", {
-      //   html(attrs, state) {
-      //     if (attrs.journal) {
-      //       return this.journalMap(attrs, state);
-      //     } else {
-      //       return this._super(attrs, state);
-      //     }
-      //   },
-
-      //   journalMap(attrs, state) {
-      //     const contents = [];
-      //     const post = this.findAncestorModel();
-      //     const topic = post.topic;
-
-      //     contents.push(
-      //       h("li", [
-      //         h("h4", I18n.t("created_lowercase")),
-      //         h("div.topic-map-post.created-at", [
-      //           avatarFor("tiny", {
-      //             username: attrs.createdByUsername,
-      //             template: attrs.createdByAvatarTemplate,
-      //             name: attrs.createdByName
-      //           }),
-      //           dateNode(attrs.topicCreatedAt)
-      //         ])
-      //       ])
-      //     );
-
-      //     let lastEntryUrl = attrs.topicUrl + "/" + topic.last_entry_post_number;
-
-      //     contents.push(
-      //       h(
-      //         "li",
-      //         h("a", { attributes: { href: lastEntryUrl } }, [
-      //           h("h4", I18n.t(`last_entry_lowercase`)),
-      //           h("div.topic-map-post.last-entry", [
-      //             avatarFor("tiny", {
-      //               username: topic.journal_author.username,
-      //               template: topic.journal_author.avatar_template,
-      //               name: topic.journal_author.name
-      //             }),
-      //             dateNode(attrs.lastPostAt)
-      //           ])
-      //         ])
-      //       )
-      //     );
-
-      //     contents.push(
-      //       h("li", [
-      //         numberNode(topic.entry_count),
-      //         h(
-      //           "h4",
-      //           I18n.t(`entry_lowercase`, { count: topic.entry_count })
-      //         )
-      //       ])
-      //     );
-
-      //     contents.push(
-      //       h("li", [
-      //         numberNode(topic.comment_count),
-      //         h(
-      //           "h4",
-      //           I18n.t(`comment_lowercase`, { count: topic.comment_count })
-      //         )
-      //       ])
-      //     );
-
-      //     contents.push(
-      //       h("li.secondary", [
-      //         numberNode(attrs.topicViews, { className: attrs.topicViewsHeat }),
-      //         h("h4", I18n.t("views_lowercase", { count: attrs.topicViews }))
-      //       ])
-      //     );
-
-      //     if (attrs.topicLikeCount) {
-      //       contents.push(
-      //         h("li.secondary", [
-      //           numberNode(attrs.topicLikeCount),
-      //           h("h4", I18n.t("likes_lowercase", { count: attrs.topicLikeCount }))
-      //         ])
-      //       );
-      //     }
-
-      //     if (attrs.topicLinkLength > 0) {
-      //       contents.push(
-      //         h("li.secondary", [
-      //           numberNode(attrs.topicLinkLength),
-      //           h("h4", I18n.t("links_lowercase", { count: attrs.topicLinkLength }))
-      //         ])
-      //       );
-      //     }
-
-      //     if (
-      //       state.collapsed &&
-      //       attrs.topicPostsCount > 2 &&
-      //       attrs.participants.length > 0
-      //     ) {
-      //       const participants = renderParticipants.call(
-      //         this,
-      //         attrs.userFilters,
-      //         attrs.participants.slice(0, 3)
-      //       );
-      //       contents.push(h("li.avatars", participants));
-      //     }
-
-      //     const nav = h(
-      //       "nav.buttons",
-      //       this.attach("button", {
-      //         title: "topic.toggle_information",
-      //         icon: state.collapsed ? "chevron-down" : "chevron-up",
-      //         action: "toggleMap",
-      //         className: "btn"
-      //       })
-      //     );
-
-      //     return [nav, h("ul.clearfix", contents)];
-      //   }
-      // });
+            return new RenderGlimmer(
+              this,
+              wrapperClass,
+              hbs`<JournalTopicMapSummary
+                @postAttrs={{@data.postAttrs}}
+                @toggleMap={{@data.toggleMap}}
+                @collapsed={{@data.collapsed}}
+              />`,
+              {
+                toggleMap: this.toggleMap.bind(this),
+                postAttrs: attrs,
+                collapsed,
+              }
+            );
+          },
+      });
     });
   }
 }


### PR DESCRIPTION
I had a great use case for this plugin in a forum I'm in the process of migrating, and I've been working on updating it to the latest `test-passed` version. The thing is that it's gotten more and more complex, and I still lack the knowledge to keep on without any help. I'm new to RoR, Ember, and Discourse.

My current roadblock are **widgets that are now components**. I don't know how to use the existing plugin outlets to do the customizations that this plugin requires. I also see myself copying more and more code from core, and I'm not sure if that is the way to go.

Finally, I'm also wondering what's the status of the plugin, I haven't been able to find any information in [meta](https://meta.discourse.org/search?q=discourse-journal), and [coop](https://coop.pavilion.tech/plugins?branch=tests-passed) says it's *compatible* with `tests-passed`.
